### PR TITLE
pin numpy version, numpy >2.0 breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ dependencies:
   - python=3.11
   - pip
   - pip:
+    - numpy==1.26.4
     - git+https://github.com/LooseLab/bulkvis.git@2.0
 ```
 

--- a/env.yml
+++ b/env.yml
@@ -7,4 +7,5 @@ dependencies:
   - python=3.11
   - pip
   - pip:
+    - numpy==1.26.4
     - git+https://github.com/LooseLab/bulkvis.git


### PR DESCRIPTION
Hi,
Hope you are doing alright? Just trying to snoop around in a bulkfile and noticed bulkvis won't start with the env specification. Looks like numpy 2.0 broke not only facebook
(https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from)
cheers,
Lukas